### PR TITLE
use /bin/sh to prevent github desktop error

### DIFF
--- a/git-hooks/reference-transaction
+++ b/git-hooks/reference-transaction
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # This hook script detectes changes on the specified remote ref (track_ref) and
 # unlocks the own file locks that have already been pushed/merged to the remote branch.


### PR DESCRIPTION
I have WSL, so when I try to push via github desktop somehow it detects wsl and tries to run hook via WLS because `/bin/bash` being used
![image](https://github.com/user-attachments/assets/baef7e60-bce6-4760-868b-2ae7c871284e)

I changed on `/bin/sh` and all works fine files unlocking on push as it should be
![image](https://github.com/user-attachments/assets/7f195c25-0efb-47cc-8c3d-ba9b6cf2d995)

--- 

BTW wanted to ask did you found solution how to unlock files on pull request merge? As I know github don't allow server side hooks, github actions? or is it done automatically when we fetch?

UPD tested - on fetch its detect that file being merged in main and unlocks it OMG you are a hero man, not git lfs locks usable for our indie studio. THANKS A LOT 